### PR TITLE
Add Prophet.fun

### DIFF
--- a/dexs/prophet-fun/index.ts
+++ b/dexs/prophet-fun/index.ts
@@ -1,0 +1,27 @@
+import fetchURL from "../../utils/fetchURL"
+import { type SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+
+const URL = "https://backend.prophet.fun/business-metrics/daily-volume"
+
+
+const fetch = async (timestamp: any) => {
+  const data = await fetchURL(URL + "?timestamp=" + timestamp.startOfDay);
+
+  return {
+    dailyVolume: data.dailyVolume,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  methodology: 'Volume of all trades that that go through the protocol',
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      start: '2025-07-24'
+    },
+  }
+};
+
+export default adapter;


### PR DESCRIPTION
Hey guys!

Name: Prophet
Twitter: https://x.com/Prophet_fun
Website: https://prophet.fun/
Chain: Solana
Description: Prophet Fun is a fast, on-chain prediction platform built on Solana. Bet on crypto price swings, whale wallet moves, narrative shifts on Crypto Twitter, and degen roulette-style markets.
Category: DEX
<img width="400" height="400" alt="prophet-fun" src="https://github.com/user-attachments/assets/b0a6456a-a892-4124-b2a6-e322a17519cc" />

